### PR TITLE
Pc switch profile defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ A simple Spring Boot webapp using:
 
 # Running on Heroku.
 
+First, when running on Heroku, you must define a configuration variable as follows:
+
+* `MAVEN_SETTINGS_PATH` should be set equal to `heroku.xml`
+* `heroku.xml` should be a file that exists in the root of the repository that contains
+  the necessary XML to configure `heroku` as the active profile.
+  (See: <https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml#defining-the-maven_settings_path-config-variable> )
+
 To run on Heroku, you must go BACK to GitHub and set up a DIFFERENT client id and client secret than the one you used for
 localhost.
 

--- a/env.sh
+++ b/env.sh
@@ -1,1 +1,2 @@
 export SPRING_APPLICATION_JSON=`cat localhost.json`
+export ACTIVE_PROFILE=localhost

--- a/heroku.xml
+++ b/heroku.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <activeProfiles>
+    <activeProfile>heroku</activeProfile>
+  </activeProfiles>
+</settings>

--- a/heroku.xml
+++ b/heroku.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <activeProfiles>
-    <activeProfile>heroku</activeProfile>
-  </activeProfiles>
-</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@
     <profiles>
         <profile>
             <id>localhost</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <resources>
                     <resource>
@@ -294,9 +297,6 @@
         </profile>
         <profile>
             <id>heroku</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <resources>
                     <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,10 @@
         <profile>
             <id>localhost</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>env.ACTIVE_PROFILE</name>
+                    <value>localhost</value>
+                </property>
             </activation>
             <build>
                 <resources>
@@ -297,6 +300,12 @@
         </profile>
         <profile>
             <id>heroku</id>
+            <activation>
+                <property>
+                    <name>env.ACTIVE_PROFILE</name>
+                    <value>heroku</value>
+                </property>
+            </activation>
             <build>
                 <resources>
                     <resource>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.output.ansi.enabled=DETECT
 logging.level.org.hibernate.SQL=debug
 
 spring.jpa.show-sql=true
+spring.jpa.generate-ddl=true


### PR DESCRIPTION
With this PR, we eliminates the need to type `-P locahost` when running the application locally; by default the `localhost` profile will be used, and on heroku, the heroku profile will be used.

To accomplish this, we:

* make `localhost` the default profile instead of `heroku`
* add a `heroku.xml` file in the root of the directory with the same syntax as the `settings.xml` file described here: <https://devcenter.heroku.com/articles/using-a-custom-maven-settings-xml#defining-the-maven_settings_path-config-variable>
* add instructions to configure the`MAVEN_SETTINGS_PATH` config var to the value `heroku.xml` (matching the name of the file above.)



The intent is to set up the heroku config variable `MAVEN_SETTINGS_PATH` with the value `heroku.xml` only on heroku.  In that file, we specify heroku as the default profile.

