### PR TITLE
pc - make default profile depend on environment variable

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,1 +1,2 @@
 export SPRING_APPLICATION_JSON=`cat localhost.json`
+export ACTIVE_PROFILE=localhost

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
     <profiles>
         <profile>
             <id>localhost</id>
+            <activation>
+                <property>
+                    <name>env.ACTIVE_PROFILE</name>
+                    <value>localhost</value>
+                </property>
+            </activation>
             <build>
                 <resources>
                     <resource>
@@ -295,7 +301,10 @@
         <profile>
             <id>heroku</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>env.ACTIVE_PROFILE</name>
+                    <value>heroku</value>
+                </property>
             </activation>
             <build>
                 <resources>


### PR DESCRIPTION
In this PR, we make the active profile depend on the environment variable `ACTIVE_PROFILE`

Each of the two profiles, `localhost` and `heroku` is activated only when the `ACTIVE_PROFILE` environment variable has the respective value.

The `env.sh` file that is required when running on `locahost` defines the environment variable appropriately.    

To run on Heroku, the user must define a configuration variable called `ACTIVE_PROFILE` to the value `heroku`.

